### PR TITLE
adapt installation for iRODS V4.1 and higher. Use version in local.re to build packages

### DIFF
--- a/packaging/create_deb_package.sh
+++ b/packaging/create_deb_package.sh
@@ -11,9 +11,11 @@ RPM_BUILD_ROOT="${HOME}/debbuild/"
 RPM_SOURCE_DIR=$B2SAFEHOME
 PRODUCT="irods-eudat-b2safe"
 IRODS_PACKAGE_DIR=`grep -i _irodsPackage ${PRODUCT}.spec | head -n 1 | awk '{print $3}'`
-# retrieve parameters from spec file. So we only have to update the spec file.
-VERSION=`grep -i "^Version:" ${PRODUCT}.spec  | awk '{print $2}'`
-RELEASE=`grep -i "^Release:" ${PRODUCT}.spec  | awk '{print $2}'`
+# retrieve parameters from local.re in tree
+MAJOR_VERS=`grep "^\s*\*major_version" $B2SAFEHOME/rulebase/local.re | awk -F\" '{print $2}'`
+MINOR_VERS=`grep "^\s*\*minor_version" $B2SAFEHOME/rulebase/local.re | awk -F\" '{print $2}'`
+VERSION="${MAJOR_VERS}.${MINOR_VERS}"
+RELEASE=`grep "^\s*\*sub_version" $B2SAFEHOME/rulebase/local.re | awk -F\" '{print $2}'`
 PACKAGE="${PRODUCT}_${VERSION}-${RELEASE}"
 
 if [ "$USERNAME" = "root" ]

--- a/packaging/create_rpm_package.sh
+++ b/packaging/create_rpm_package.sh
@@ -30,7 +30,16 @@ else
 	echo '%_topdir %(echo $HOME)/rpmbuild' > ~/.rpmmacros
 fi
 
+# find directory where we are executing:
+ABSOLUTE_PATH=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)
+
+#extract major_version, minor_version and subversion from local.re in tree
+MAJOR_VERS=`grep "^\s*\*major_version" $ABSOLUTE_PATH/../rulebase/local.re | awk -F\" '{print $2}'`
+MINOR_VERS=`grep "^\s*\*minor_version" $ABSOLUTE_PATH/../rulebase/local.re | awk -F\" '{print $2}'`
+SUB_VERS=`grep "^\s*\*sub_version" $ABSOLUTE_PATH/../rulebase/local.re | awk -F\" '{print $2}'`
+VERSION="${MAJOR_VERS}.${MINOR_VERS}"
+
 # build rpm
-rpmbuild -ba irods-eudat-b2safe.spec
+rpmbuild -ba --define "_version $VERSION" --define "_release $SUB_VERS" irods-eudat-b2safe.spec
 
 # done..

--- a/packaging/irods-eudat-b2safe.spec
+++ b/packaging/irods-eudat-b2safe.spec
@@ -1,6 +1,6 @@
 Name:		irods-eudat-b2safe
-Version:	3.0
-Release:	0
+Version:	%{_version}
+Release:	%{_release}
 #Release:	1%{?dist}
 Summary:	b2safe core application for iRODS v4
 
@@ -147,6 +147,8 @@ cd %{_irodsPackage}/packaging
 EOF
 
 %changelog
+* Mon Jul 07 2015  Robert Verkerk <robert.verkerk@surfsara.nl> 3.0
+- assign version of package at build time with input parameters 
 * Fri Feb 13 2015  Robert Verkerk <robert.verkerk@surfsara.nl> 3.0
 - Add files to b2safe package
 * Wed Jan 28 2015  Robert Verkerk <robert.verkerk@surfsara.nl> 3.0


### PR DESCRIPTION

use version parameters in rulebase/local.re to assign version of package when building.

adapt installation scripts for iRODS 4.1 and higher. Implement update of json files.
prepare for automatic update of authz.map.json. This feature is NOT activated.