### PR TITLE
Add support for Python < 2.7 for running EPIC Client unit/integrations tests

### DIFF
--- a/scripts/tests/testB2SafeCmd/epicapitest.py
+++ b/scripts/tests/testB2SafeCmd/epicapitest.py
@@ -1,4 +1,8 @@
-import unittest
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 import mock
 import httplib2
 from lxml import etree 
@@ -6,7 +10,6 @@ from lxml.etree import tostring
 import simplejson
 import base64
 import os.path
-import sys
 
 sys.path.append("../../cmd") 
 import epicclient

--- a/scripts/tests/testB2SafeCmd/epicclitest.py
+++ b/scripts/tests/testB2SafeCmd/epicclitest.py
@@ -1,6 +1,9 @@
-import unittest
-import mock
 import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+import mock
 import argparse
 
 sys.path.append("../../cmd") 

--- a/scripts/tests/testB2SafeCmd/epiccredtest.py
+++ b/scripts/tests/testB2SafeCmd/epiccredtest.py
@@ -1,5 +1,8 @@
-import unittest
 import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 sys.path.append("../../cmd") 
 import epicclient

--- a/scripts/tests/testB2SafeCmd/epicintgtest.py
+++ b/scripts/tests/testB2SafeCmd/epicintgtest.py
@@ -1,5 +1,8 @@
-import unittest
 import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 import os
 import os.path
 


### PR DESCRIPTION
This PR adds support for running EPIC Client unit/integrations tests with versions of Python earlier than 2.7. Many new features were added to `unittest` in Python 2.7, so this PR conditionally imports `unittest2` which allows using these features with earlier versions of Python.

Note that the PR has only been tested with Python 2.6.

/cc @cookie33, @ccacciari, @TobiasWeigel  