### PR TITLE
b2safe installation improvement

### DIFF
--- a/install.txt
+++ b/install.txt
@@ -1,6 +1,6 @@
 *** Installation ***
 
-The following describes the procedure to enable B2SAFE release-3.0.0
+The following describes the procedure to enable B2SAFE release-3.x.y
 
 NOTE: iRODS is running as a normal user process. NOT as root. The package can
 be build by any user. During installation of the package it will use: 
@@ -42,7 +42,7 @@ To install/configure it in iRODS do following as the user who runs iRODS :
 sudo vi /opt/eudat/b2safe/packaging/install.conf
 
 # install/configure it as the user who runs iRODS
-source /etc/irods/service_account.conf 
+source /etc/irods/service_account.config
 sudo su - $IRODS_SERVICE_ACCOUNT_NAME -s "/bin/bash" -c "cd /opt/eudat/b2safe/packaging/ ; ./install.sh"
 
 

--- a/install.txt
+++ b/install.txt
@@ -2,19 +2,20 @@
 
 The following describes the procedure to enable B2SAFE release-3.0.0
 
-NOTE: iRODS is running as a normal user process. NOT as root. The package needs 
-to be build by the user who runs iRODS. In the examples the user who runs 
-iRODS is "irods".
+NOTE: iRODS is running as a normal user process. NOT as root. The package can
+be build by any user. During installation of the package it will use: 
+"/etc/irods/service_account.config" to set the ownership of the files.
+
 
 It works as follows:
-- clone the b2safe project under the user which runs irods. NOT root
+- clone the b2safe project as any user. NOT root
   $ git clone https://github.com/EUDAT-B2SAFE/B2SAFE-core.git
 - go to the directory where the packaging files are:
   $ cd B2SAFE-core/packaging
 
 * RPM *
 
-- create package for the user who runs the irods instance:
+- create package:
   $ ./create_rpm_package.sh
 - login as root and install package:
   # rpm -ivh /home/irods/rpmbuild/RPMS/noarch/irods-eudat-b2safe-3.0-0.noarch.rpm
@@ -23,10 +24,10 @@ It works as follows:
 
 * DEB *
 
-- create package for the user who runs the irods instance:
+- create package:
   $ ./create_deb_package.sh
 - login as root or use sudo to install package:
-  # dpkg -i --ignore-depends irods-icat /home/irods/debbuild/irods-eudat-b2safe_3.0-0.deb
+  $ sudo dpkg -i  /home/irods/debbuild/irods-eudat-b2safe_3.0-0.deb
   Selecting previously unselected package irods-eudat-b2safe.
   (Reading database ... .... files and directories currently installed.)
   Preparing to unpack .../irods-eudat-b2safe_3.0-0.deb ...
@@ -34,22 +35,36 @@ It works as follows:
   Setting up irods-eudat-b2safe (3.0-0) ...
 
 
-  The package b2safe has been installed in /opt/eudat/b2safe.
-  To install/configure it in iRODS do following as the user "irods" which runs iRODS 
+The package b2safe has been installed in /opt/eudat/b2safe.
+To install/configure it in iRODS do following as the user who runs iRODS :
+
+# update install.conf with correct parameters with your favorite editor
+sudo vi /opt/eudat/b2safe/packaging/install.conf
+
+# install/configure it as the user who runs iRODS
+source /etc/irods/service_account.conf 
+sudo su - $IRODS_SERVICE_ACCOUNT_NAME -s "/bin/bash" -c "cd /opt/eudat/b2safe/packaging/ ; ./install.sh"
 
 
-- Perform the after installation tuning/updates as the user who runs the irods instance.
-  su - irods
-  cd /opt/eudat/b2safe/packaging
-  # update install.conf with correct parameters with your favorite editor. The 
-  # following need to be updated:
-    - DEFAULT_RESOURCE
-    - SERVER_ID
-    - BASE_URI
-    - USERNAME
-    - PREFIX
-  - perform the postinstallation script
-  $ ./install.sh
+
+NOTE: following need to be updated in "/opt/eudat/b2safe/packaging/install.conf":
+   - DEFAULT_RESOURCE
+   - SERVER_ID
+   - BASE_URI
+   - USERNAME
+   - PREFIX
+
+
+- check the python scripts for missing python libraries.
+  $ cd /opt/eudat/b2safe/cmd
+  $ ./authZmanager.py -h
+  $ ./epicclient.py --help
+  $ ./logmanager.py -h
+  $ ./messageManager.py -h
+  $ ./metadataManager.py -h
+
+Try to install missing packes with the standard package manager like apt, yum, zypper etc.
+If packages are not within the standards use pip and install the missing packages with pip. 
 
 
 DONE

--- a/packaging/create_deb_package.sh
+++ b/packaging/create_deb_package.sh
@@ -150,7 +150,7 @@ To install/configure it in iRODS do following as the user who runs iRODS :
 sudo vi ${IRODS_PACKAGE_DIR}/packaging/install.conf
 
 # install/configure it as the user who runs iRODS
-source /etc/irods/service_account.conf 
+source /etc/irods/service_account.config 
 sudo su - \\\$IRODS_SERVICE_ACCOUNT_NAME -s "/bin/bash" -c "cd ${IRODS_PACKAGE_DIR}/packaging/ ; ./install.sh"
 
 EOF1

--- a/packaging/create_deb_package.sh
+++ b/packaging/create_deb_package.sh
@@ -3,8 +3,6 @@
 #set -x
 
 USERNAME=`whoami`
-IRODSUID=`id -un $USERNAME`
-IRODSGID=`id -gn $USERNAME`
 B2SAFEHOMEPACKAGING="$(cd $(dirname "$0"); pwd)"
 B2SAFEHOME=`dirname $B2SAFEHOMEPACKAGING`
 RPM_BUILD_ROOT="${HOME}/debbuild/"
@@ -21,7 +19,7 @@ PACKAGE="${PRODUCT}_${VERSION}-${RELEASE}"
 if [ "$USERNAME" = "root" ]
 then
 	echo "We are NOT allowed to run as root, exit"
-        echo "Run this script/procedure as the user who run's iRODS"
+        echo "Run this script/procedure as any user except root"
 	exit 1
 fi
 
@@ -137,12 +135,7 @@ LOG_LEVEL=DEBUG
 LOG_DIR=/var/log/irods
 #
 #
-SHARED_SPACE=/Zone0/replicate
-
 EOF2
-
-# set correct owner of file
-chown $IRODSUID:$IRODSGID \$INSTALL_CONF
 
 fi
 
@@ -151,14 +144,25 @@ fi
 cat << EOF1
 
 The package b2safe has been installed in ${IRODS_PACKAGE_DIR}.
-To install/configure it in iRODS do following as the user "$USERNAME" which runs iRODS 
+To install/configure it in iRODS do following as the user who runs iRODS :
 
-su - $USERNAME
-cd ${IRODS_PACKAGE_DIR}/packaging
 # update install.conf with correct parameters with your favorite editor
-./install.sh
+sudo vi ${IRODS_PACKAGE_DIR}/packaging/install.conf
+
+# install/configure it as the user who runs iRODS
+source /etc/irods/service_account.conf 
+sudo su - \\\$IRODS_SERVICE_ACCOUNT_NAME -s "/bin/bash" -c "cd ${IRODS_PACKAGE_DIR}/packaging/ ; ./install.sh"
 
 EOF1
+
+# set owner of files to the user who run's iRODS
+IRODS_SERVICE_ACCOUNT_CONFIG=/etc/irods/service_account.config
+if [ -e \$IRODS_SERVICE_ACCOUNT_CONFIG ]
+then
+    source \$IRODS_SERVICE_ACCOUNT_CONFIG
+    chown -R \$IRODS_SERVICE_ACCOUNT_NAME:\$IRODS_SERVICE_GROUP_NAME ${IRODS_PACKAGE_DIR} 
+    chown -R \$IRODS_SERVICE_ACCOUNT_NAME:\$IRODS_SERVICE_GROUP_NAME /var/log/irods
+fi
 
 EOF
 

--- a/packaging/create_rpm_package.sh
+++ b/packaging/create_rpm_package.sh
@@ -5,7 +5,7 @@ USERNAME=`whoami`
 if [ "$USERNAME" = "root" ]
 then
 	echo "We are NOT allowed to run as root, exit"
-        echo "Run this script/procedure as the user who run's iRODS"
+        echo "Run this script/procedure as any user except root"
 	exit 1
 fi
 

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -71,7 +71,9 @@ read_parameters() {
             source $IRODS_SERVICE_ACCOUNT_CONFIG
         else
             echo "ERROR: $IRODS_SERVICE_ACCOUNT_CONFIG not present!"
-            echo "Is iRODS installed?"
+            echo "At the moment the file ownership of the b2safe package is wrong!"
+            echo "Is iRODS configured?"
+            echo "Remove the b2safe package and re-install after configuring iRODS"
             STATUS=1
         fi
     fi

--- a/packaging/irods-eudat-b2safe.spec
+++ b/packaging/irods-eudat-b2safe.spec
@@ -154,7 +154,7 @@ To install/configure it in iRODS do following as the user who runs iRODS :
 sudo vi %{_irodsPackage}/packaging/install.conf
 
 # install/configure it as the user who runs iRODS
-source /etc/irods/service_account.conf 
+source /etc/irods/service_account.config 
 sudo su - \$IRODS_SERVICE_ACCOUNT_NAME -s "/bin/bash" -c "cd %{_irodsPackage}/packaging/ ; ./install.sh"
 
 EOF

--- a/packaging/irods-eudat-b2safe.spec
+++ b/packaging/irods-eudat-b2safe.spec
@@ -15,8 +15,6 @@ BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 Requires:	irods-icat
 
 %define _whoami %(whoami)
-%define _irodsUID %(id -un `whoami`)
-%define _irodsGID %(id -gn `whoami`)
 %define _b2safehomepackaging %(pwd)
 %define _irodsPackage /opt/eudat/b2safe
  
@@ -75,7 +73,7 @@ rm -rf %{buildroot}
 #provide files to rpm. Set attributes 
 %files
 # default attributes
-%defattr(-,%{_irodsUID},%{_irodsUID},-)
+%defattr(-,-,-,-)
 # files
 # exclude .pyc and .py files
 %exclude %{_irodsPackage}/cmd/*.pyc
@@ -87,12 +85,12 @@ rm -rf %{buildroot}
 %{_irodsPackage}/rulebase
 %{_irodsPackage}/testRules
 # attributes on files and directory's
-%attr(-,%{_irodsUID},%{_irodsGID})   %{_irodsPackage}
-%attr(700,%{_irodsUID},%{_irodsGID}) %{_irodsPackage}/cmd/*.py
-%attr(600,%{_irodsUID},%{_irodsGID}) %{_irodsPackage}/conf/*.json
-%attr(600,%{_irodsUID},%{_irodsGID}) %{_irodsPackage}/conf/*.conf
-%attr(700,%{_irodsUID},%{_irodsGID}) %{_irodsPackage}/packaging/*.sh
-%attr(-,%{_irodsUID},%{_irodsGID}) /var/log/irods
+%attr(-,-,-)   %{_irodsPackage}
+%attr(700,-,-) %{_irodsPackage}/cmd/*.py
+%attr(600,-,-) %{_irodsPackage}/conf/*.json
+%attr(600,-,-) %{_irodsPackage}/conf/*.conf
+%attr(700,-,-) %{_irodsPackage}/packaging/*.sh
+%attr(-,-,-)   /var/log/irods
 %doc
 # config files
 %config(noreplace) %{_irodsPackage}/conf/*.json
@@ -141,11 +139,8 @@ LOG_LEVEL=DEBUG
 LOG_DIR=/var/log/irods
 #
 #
-SHARED_SPACE=/Zone0/replicate
 
 EOF
-
-chown %{_irodsUID}:%{_irodsGID} $INSTALL_CONF
 
 fi
 
@@ -153,16 +148,30 @@ fi
 cat << EOF
 
 The package b2safe has been installed in %{_irodsPackage}.
-To install/configure it in iRODS do following as the user %{_irodsUID} : 
+To install/configure it in iRODS do following as the user who runs iRODS :
 
-su - %{_irodsUID}
-cd %{_irodsPackage}/packaging
 # update install.conf with correct parameters with your favorite editor
-./install.sh
+sudo vi %{_irodsPackage}/packaging/install.conf
+
+# install/configure it as the user who runs iRODS
+source /etc/irods/service_account.conf 
+sudo su - \$IRODS_SERVICE_ACCOUNT_NAME -s "/bin/bash" -c "cd %{_irodsPackage}/packaging/ ; ./install.sh"
 
 EOF
 
+# set owner of files to the user who run's iRODS
+IRODS_SERVICE_ACCOUNT_CONFIG=/etc/irods/service_account.config
+if [ -e $IRODS_SERVICE_ACCOUNT_CONFIG ]
+then
+    source $IRODS_SERVICE_ACCOUNT_CONFIG
+    chown -R $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME %{_irodsPackage}
+    chown -R $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/log/irods
+fi
+
+
 %changelog
+* Fri Nov 20 2015  Robert Verkerk <robert.verkerk@surfsara.nl> 3.0.0
+- set owner of files during installation of rpm.
 * Fri Oct 23 2015  Robert Verkerk <robert.verkerk@surfsara.nl> 3.0.0
 - remove docs directory.
 * Thu Oct 15 2015  Robert Verkerk <robert.verkerk@surfsara.nl> 3.0


### PR DESCRIPTION
The installation improvement addresses following:

1>
The rpm or deb package can now be created as any user (except root).
The package will be installed as the user root.

For this to work iRODS has to be installed and configured. The file "/etc/irods/service_account.config" has to be present and will be used to set the ownership of the directories and files under "/opt/eudat/b2safe" and "/var/log/irods".

This way any user can create the rpm or deb package. So even eudat could provide the packages in a static place and the users don't have to build them.

2>
The install.sh scripts has been made more robust. if a step fails it now falls through till the end. Before it would skip one step and continue with the installation.

Robert