### PR TITLE
Fix undefined class error in testB2SafeCmd.py (Closes #46)

### DIFF
--- a/scripts/tests/testB2SafeCmd.py
+++ b/scripts/tests/testB2SafeCmd.py
@@ -11,6 +11,18 @@ import unittest
 
 __author__ = 'lphan'
 
+def create_epic_test_suite():
+    epic_api_suite = unittest.TestLoader().loadTestsFromTestCase(
+        EpicClientAPITestCase)
+    epic_cred_suite = unittest.TestLoader().loadTestsFromTestCase(
+        EpicClientCredentialsTestCase)
+    epic_cli_suite = unittest.TestLoader().loadTestsFromTestCase(
+        EpicClientCLITestCase)
+    epic_it_suite = unittest.TestLoader().loadTestsFromTestCase(
+        EpicClientIntegrationTests)
+    return unittest.TestSuite(
+        [epic_api_suite, epic_cred_suite, epic_cli_suite, epic_it_suite])
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Test script for epicclient '
                                                  '(epic), '
@@ -25,16 +37,7 @@ if __name__ == '__main__':
     if param.script == "epic":
         # Test cases for B2Safe-Epicclient#
         print "Test Epicclient Script"
-        epic_api_suite = unittest.TestLoader().loadTestsFromTestCase(
-            EpicClientAPITestCase)
-        epic_cred_suite = unittest.TestLoader().loadTestsFromTestCase(
-            EpicClientCredentialsTestCase)
-        epic_cli_suite = unittest.TestLoader().loadTestsFromTestCase(
-            EpicClientCLITestCase)
-        epic_it_suite = unittest.TestLoader().loadTestsFromTestCase(
-            EpicClientIntegrationTests)
-        epic_suite = unittest.TestSuite(
-            [epic_api_suite, epic_cred_suite, epic_cli_suite, epic_it_suite])
+        epic_suite = create_epic_test_suite()
         unittest.TextTestRunner(descriptions=2, verbosity=2).run(epic_suite)
 
     elif param.script == "log":
@@ -56,8 +59,8 @@ if __name__ == '__main__':
         print "run authZmanager.py - if true then run epicclient2beta and log "\
               "with logmanager.py"
         all_suite = unittest.TestSuite()
+        all_suite.addTest(create_epic_test_suite())
         all_suite.addTest(AuthzManagerTestCase("test_case"))
-        all_suite.addTest(EpicClientTestCase("test_case"))
         all_suite.addTest(LogManagerTestCase("test_case"))
         unittest.TextTestRunner(descriptions=2, verbosity=2).run(all_suite)
 


### PR DESCRIPTION
This PR fixes the `"NameError: name 'EpicClientTestCase' is not defined"` error when invoking `testB2SafeCmd.py` with `-test all`. The classes that are now being used are:
* `EpicClientAPITestCase`
* `EpicClientCredentialsTestCase`, 
* `EpicClientCLITestCase` and 
* `EpicClientIntegrationTest`

/cc @javiquinte 

