### PR TITLE
Handle version 8 implementation with handle API and reverse lookup servlet

### DIFF
--- a/cmd/epicclient2.py
+++ b/cmd/epicclient2.py
@@ -28,6 +28,17 @@ def search(args):
 
     # load credentials
     credentials = PIDClientCredentials.load_from_JSON(args.credpath)
+    # set username and password for search
+    if 'reverse_username' in credentials.get_config():
+        reverselookup_username = credentials.get_config()['reverse_username']
+    else:
+        reverselookup_username = credentials.get_prefix()
+
+    if 'reverse_password' in credentials.get_config():
+        reverselookup_password = credentials.get_config()['reverse_password']
+    else:
+        reverselookup_password = credentials.get_password()
+
     # retrieve and set extra values
     extra_config = {}
     if 'HTTPS_verify' in credentials.get_config():
@@ -36,8 +47,8 @@ def search(args):
     # setup connection to handle server
     client = EUDATHandleClient.instantiate_for_read_and_search(
         credentials.get_server_URL(),
-        credentials.get_prefix(),
-        credentials.get_password(),
+        reverselookup_username,
+        reverselookup_password,
         **extra_config)
 
     kvpairs = dict([(args.key, str(''.join(args.value)))])
@@ -57,6 +68,17 @@ def read(args):
 
     # load credentials
     credentials = PIDClientCredentials.load_from_JSON(args.credpath)
+    # set username and password for search
+    if 'reverse_username' in credentials.get_config():
+        reverselookup_username = credentials.get_config()['reverse_username']
+    else:
+        reverselookup_username = credentials.get_prefix()
+
+    if 'reverse_password' in credentials.get_config():
+        reverselookup_password = credentials.get_config()['reverse_password']
+    else:
+        reverselookup_password = credentials.get_password()
+
     # retrieve and set extra values
     extra_config = {}
     if 'HTTPS_verify' in credentials.get_config():
@@ -65,8 +87,8 @@ def read(args):
     # setup connection to handle server
     client = EUDATHandleClient.instantiate_for_read_and_search(
         credentials.get_server_URL(),
-        credentials.get_prefix(),
-        credentials.get_password(),
+        reverselookup_username,
+        reverselookup_password,
         **extra_config)
 
     # set default return value

--- a/cmd/epicclient2.py
+++ b/cmd/epicclient2.py
@@ -28,6 +28,7 @@ def search(args):
 
     # load credentials
     credentials = PIDClientCredentials.load_from_JSON(args.credpath)
+
     # set username and password for search
     if 'reverse_username' in credentials.get_config():
         reverselookup_username = credentials.get_config()['reverse_username']
@@ -41,8 +42,6 @@ def search(args):
 
     # retrieve and set extra values
     extra_config = {}
-    if 'HTTPS_verify' in credentials.get_config():
-        extra_config['HTTPS_verify'] = credentials.get_config()['HTTPS_verify']
 
     # setup connection to handle server
     client = EUDATHandleClient.instantiate_for_read_and_search(
@@ -68,27 +67,13 @@ def read(args):
 
     # load credentials
     credentials = PIDClientCredentials.load_from_JSON(args.credpath)
-    # set username and password for search
-    if 'reverse_username' in credentials.get_config():
-        reverselookup_username = credentials.get_config()['reverse_username']
-    else:
-        reverselookup_username = credentials.get_prefix()
-
-    if 'reverse_password' in credentials.get_config():
-        reverselookup_password = credentials.get_config()['reverse_password']
-    else:
-        reverselookup_password = credentials.get_password()
 
     # retrieve and set extra values
     extra_config = {}
-    if 'HTTPS_verify' in credentials.get_config():
-        extra_config['HTTPS_verify'] = credentials.get_config()['HTTPS_verify']
 
     # setup connection to handle server
-    client = EUDATHandleClient.instantiate_for_read_and_search(
+    client = EUDATHandleClient.instantiate_for_read_access(
         credentials.get_server_URL(),
-        reverselookup_username,
-        reverselookup_password,
         **extra_config)
 
     # set default return value
@@ -116,10 +101,9 @@ def create(args):
 
     # load credentials
     credentials = PIDClientCredentials.load_from_JSON(args.credpath)
+
     # retrieve and set extra values
     extra_config = {}
-    if 'HTTPS_verify' in credentials.get_config():
-        extra_config['HTTPS_verify'] = credentials.get_config()['HTTPS_verify']
 
     # create a handle to put. Concate the prefix with a new generated suffix
     prefix = str(credentials.get_prefix())
@@ -164,10 +148,9 @@ def modify(args):
 
     # load credentials
     credentials = PIDClientCredentials.load_from_JSON(args.credpath)
+
     # retrieve and set extra values
     extra_config = {}
-    if 'HTTPS_verify' in credentials.get_config():
-        extra_config['HTTPS_verify'] = credentials.get_config()['HTTPS_verify']
 
     # setup connection to handle server
     client = EUDATHandleClient.instantiate_with_credentials(
@@ -196,10 +179,9 @@ def delete(args):
 
     # load credentials
     credentials = PIDClientCredentials.load_from_JSON(args.credpath)
+
     # retrieve and set extra values
     extra_config = {}
-    if 'HTTPS_verify' in credentials.get_config():
-        extra_config['HTTPS_verify'] = credentials.get_config()['HTTPS_verify']
 
     # setup connection to handle server
     client = EUDATHandleClient.instantiate_with_credentials(
@@ -221,10 +203,9 @@ def relation(args):
 
     # load credentials
     credentials = PIDClientCredentials.load_from_JSON(args.credpath)
+
     # retrieve and set extra values
     extra_config = {}
-    if 'HTTPS_verify' in credentials.get_config():
-        extra_config['HTTPS_verify'] = credentials.get_config()['HTTPS_verify']
 
     # setup connection to handle server
     client = EUDATHandleClient.instantiate_with_credentials(

--- a/cmd/epicclient2.py
+++ b/cmd/epicclient2.py
@@ -34,7 +34,6 @@ def search(args):
         extra_config['HTTPS_verify'] = credentials.get_config()['HTTPS_verify']
 
     # setup connection to handle server
-    #client = EUDATHandleClient.instantiate_with_credentials(credentials)
     client = EUDATHandleClient.instantiate_for_read_and_search(
         credentials.get_server_URL(),
         credentials.get_prefix(),
@@ -64,7 +63,6 @@ def read(args):
         extra_config['HTTPS_verify'] = credentials.get_config()['HTTPS_verify']
 
     # setup connection to handle server
-    #client = EUDATHandleClient.instantiate_with_credentials(credentials)
     client = EUDATHandleClient.instantiate_for_read_and_search(
         credentials.get_server_URL(),
         credentials.get_prefix(),
@@ -108,11 +106,8 @@ def create(args):
     handle = prefix+"/"+suffix
 
     # setup connection to handle server
-    client = EUDATHandleClient.instantiate_with_username_and_password(
-        credentials.get_server_URL(),
-        credentials.get_username(),
-        credentials.get_password(),
-        reverselookup_username=credentials.get_prefix(),
+    client = EUDATHandleClient.instantiate_with_credentials(
+        credentials,
         **extra_config)
 
     # pre-process the input parameters for the handle api
@@ -153,11 +148,8 @@ def modify(args):
         extra_config['HTTPS_verify'] = credentials.get_config()['HTTPS_verify']
 
     # setup connection to handle server
-    client = EUDATHandleClient.instantiate_with_username_and_password(
-        credentials.get_server_URL(),
-        credentials.get_username(),
-        credentials.get_password(),
-        reverselookup_username=credentials.get_prefix(),
+    client = EUDATHandleClient.instantiate_with_credentials(
+        credentials,
         **extra_config)
 
     kvpairs = dict([(args.key, args.value)])
@@ -188,11 +180,8 @@ def delete(args):
         extra_config['HTTPS_verify'] = credentials.get_config()['HTTPS_verify']
 
     # setup connection to handle server
-    client = EUDATHandleClient.instantiate_with_username_and_password(
-        credentials.get_server_URL(),
-        credentials.get_username(),
-        credentials.get_password(),
-        reverselookup_username=credentials.get_prefix(),
+    client = EUDATHandleClient.instantiate_with_credentials(
+        credentials,
         **extra_config)
 
     if args.key is None:
@@ -216,11 +205,8 @@ def relation(args):
         extra_config['HTTPS_verify'] = credentials.get_config()['HTTPS_verify']
 
     # setup connection to handle server
-    client = EUDATHandleClient.instantiate_with_username_and_password(
-        credentials.get_server_URL(),
-        credentials.get_username(),
-        credentials.get_password(),
-        reverselookup_username=credentials.get_prefix(),
+    client = EUDATHandleClient.instantiate_with_credentials(
+        credentials,
         **extra_config)
 
     # add relation to 10320/LOC


### PR DESCRIPTION
This first commit enables:

* B2HANDLE API

It has a new epicclient2.py which uses certificates and the B2HANDLE API.

The B2HANDLE API uses:
* handle software API
* handle software reverselookup servlet.

For this to work with credentials B2HANDLE version 1.0.1 has to be installed on the same system as the epicclient2.py is started.

An example of the epicclient2.py credentials file is:
```
{
    "handle_server_url": "https://fqdn:<port>",
    "private_key": "/<path>/<index>_<prefix>_ADMIN_privkey.pem",
    "certificate_only": "/<path>/<index>_<prefix>_ADMIN_certificate_only.pem",
    "prefix": "<prefix>",
    "handleowner": "200:0.NA/<prefix>",
    "reverse_username": "<prefix>",
    "reverse_password": "<password>",
    "HTTPS_verify": "True"
}
```
How to create the client certificate is described on the webpage: http://eudat-b2safe.github.io/B2HANDLE/