### PR TITLE
Add EUDAT iRODS rules behavioral parameters.

### DIFF
--- a/packaging/create_deb_package.sh
+++ b/packaging/create_deb_package.sh
@@ -135,6 +135,18 @@ LOG_LEVEL=DEBUG
 LOG_DIR=/var/log/irods
 #
 #
+# iRODS behavioral parameters
+#
+# check if user is authorized to perform several functions
+AUTHZ_ENABLED=true
+#
+# enable if iRODS contrib package is installed with msifree microservice to
+# prevent memory leaks in iRODS
+MSIFREE_ENABLED=true
+#
+# enable if a speedup is to be used. (won't work in future versions)
+MSICURL_ENABLED=false
+#
 EOF2
 
 fi

--- a/packaging/irods-eudat-b2safe.spec
+++ b/packaging/irods-eudat-b2safe.spec
@@ -139,6 +139,18 @@ LOG_LEVEL=DEBUG
 LOG_DIR=/var/log/irods
 #
 #
+# iRODS behavioral parameters
+#
+# check if user is authorized to perform several functions
+AUTHZ_ENABLED=true
+#
+# enable if iRODS contrib package is installed with msifree microservice to
+# prevent memory leaks in iRODS
+MSIFREE_ENABLED=true
+#
+# enable if a speedup is to be used. (won't work in future versions)
+MSICURL_ENABLED=false
+#
 
 EOF
 


### PR DESCRIPTION
Add the following EUDAT iRODS rules behavioral parameters.
For existing configurations it is:
```
AUTHZ_ENABLED=true
MSIFREE_ENABLED=false
MSICURL_ENABLED=false)
```
For new configurations it is:
```
AUTHZ_ENABLED=true
MSIFREE_ENABLED=true
MSICURL_ENABLED=false)
```

If a new installations done the install.conf is automatically created with these parameters

if an upgrade is done the user has to add to `/opt/eudat/b2safe/conf/install.conf`:
```
#
#
# iRODS behavioral parameters
#
# check if user is authorized to perform several functions
AUTHZ_ENABLED=true
#
# enable if iRODS contrib package is installed with msifree microservice to
# prevent memory leaks in iRODS
MSIFREE_ENABLED=true
#
# enable if a speedup is to be used. (won't work in future versions)
MSICURL_ENABLED=false
```
This needs to be added to the installation text/manual.