### PR TITLE
remove temporary code after bug fix in b2handle library.

### DIFF
--- a/cmd/epicclient2.py
+++ b/cmd/epicclient2.py
@@ -29,25 +29,12 @@ def search(args):
     # load credentials
     credentials = PIDClientCredentials.load_from_JSON(args.credpath)
 
-    # set username and password for search
-    if 'reverse_username' in credentials.get_config():
-        reverselookup_username = credentials.get_config()['reverse_username']
-    else:
-        reverselookup_username = credentials.get_prefix()
-
-    if 'reverse_password' in credentials.get_config():
-        reverselookup_password = credentials.get_config()['reverse_password']
-    else:
-        reverselookup_password = credentials.get_password()
-
     # retrieve and set extra values
     extra_config = {}
 
     # setup connection to handle server
-    client = EUDATHandleClient.instantiate_for_read_and_search(
-        credentials.get_server_URL(),
-        reverselookup_username,
-        reverselookup_password,
+    client = EUDATHandleClient.instantiate_with_credentials(
+        credentials,
         **extra_config)
 
     kvpairs = dict([(args.key, str(''.join(args.value)))])
@@ -72,8 +59,8 @@ def read(args):
     extra_config = {}
 
     # setup connection to handle server
-    client = EUDATHandleClient.instantiate_for_read_access(
-        credentials.get_server_URL(),
+    client = EUDATHandleClient.instantiate_with_credentials(
+        credentials,
         **extra_config)
 
     # set default return value


### PR DESCRIPTION
use reverselookup_username and reverselookup_password to search from credentials after bug fix.

Now use reverselookup_username and reverselookup_password as intended in b2handle library 1.0.3 and higher.