### PR TITLE
include python exceptions in epicclient2.py

### DIFF
--- a/cmd/epicclient.py
+++ b/cmd/epicclient.py
@@ -274,6 +274,13 @@ class EpicClient(object):
             for key_value in extratype:
                 key = key_value.split('=')[0]
                 value = key_value.split('=')[1]
+                # replace "EUDAT/ROR=pid" with "EUDAT/ROR=handle"
+                if key == 'EUDAT/ROR' and value.lower() == 'pid':
+                    if uri.startswith(self.cred.baseuri):
+                       handle = uri[len(self.cred.baseuri):len(uri)]
+                    elif uri.startswith(self.cred.baseuri + '/'):
+                       handle = uri[len(self.cred.baseuri + '/'):len(uri)]
+                    value = handle
                 if (next((item for item in handle_array if item['type'] == key),
                          None) is None):
                     handle_array.append({'type': key, 'parsed_data': value})

--- a/cmd/epicclient2.py
+++ b/cmd/epicclient2.py
@@ -157,11 +157,19 @@ def create(args):
         exlist = args.extratype.split(';')
         for item in exlist:
             key = item.split('=')[0]
-            extype[key] = item.split('=')[1]
+            value = item.split('=')[1]
+            extype[key] = value
     if args.loc10320 is not None:
         l10320 = args.loc10320.split(';')
     else:
         l10320 = None
+
+
+    # replace "EUDAT/ROR=pid" with "EUDAT/ROR=handle"
+    key = 'EUDAT/ROR'
+    if key in extype:
+        if extype[key].lower() == 'pid':
+            extype[key] = handle
 
     result = ''
 

--- a/cmd/epicclient2.py
+++ b/cmd/epicclient2.py
@@ -27,16 +27,27 @@ import json
 def search(args):
     """perform search action"""
 
-    # load credentials
-    credentials = PIDClientCredentials.load_from_JSON(args.credpath)
+    try:
+        # load credentials
+        credentials = PIDClientCredentials.load_from_JSON(args.credpath)
+    except CredentialsFormatError:
+        sys.stdout.write('error')
+        return
+    except HandleSyntaxError:
+        sys.stdout.write('error')
+        return
 
     # retrieve and set extra values
     extra_config = {}
 
-    # setup connection to handle server
-    client = EUDATHandleClient.instantiate_with_credentials(
-        credentials,
-        **extra_config)
+    try:
+        # setup connection to handle server
+        client = EUDATHandleClient.instantiate_with_credentials(
+            credentials,
+            **extra_config)
+    except HandleNotFoundException:
+        sys.stdout.write('error')
+        return
 
     kvpairs = dict([(args.key, str(''.join(args.value)))])
 
@@ -59,16 +70,27 @@ def search(args):
 def read(args):
     """perform read action"""
 
-    # load credentials
-    credentials = PIDClientCredentials.load_from_JSON(args.credpath)
+    try:
+        # load credentials
+        credentials = PIDClientCredentials.load_from_JSON(args.credpath)
+    except CredentialsFormatError:
+        sys.stdout.write('error')
+        return
+    except HandleSyntaxError:
+        sys.stdout.write('error')
+        return
 
     # retrieve and set extra values
     extra_config = {}
 
-    # setup connection to handle server
-    client = EUDATHandleClient.instantiate_with_credentials(
-        credentials,
-        **extra_config)
+    try:
+        # setup connection to handle server
+        client = EUDATHandleClient.instantiate_with_credentials(
+            credentials,
+            **extra_config)
+    except HandleNotFoundException:
+        sys.stdout.write('error')
+        return
 
     # set default return value
     json_result = "None"
@@ -101,8 +123,15 @@ def read(args):
 def create(args):
     """perform create action"""
 
-    # load credentials
-    credentials = PIDClientCredentials.load_from_JSON(args.credpath)
+    try:
+        # load credentials
+        credentials = PIDClientCredentials.load_from_JSON(args.credpath)
+    except CredentialsFormatError:
+        sys.stdout.write('error')
+        return
+    except HandleSyntaxError:
+        sys.stdout.write('error')
+        return
 
     # retrieve and set extra values
     extra_config = {}
@@ -113,10 +142,14 @@ def create(args):
     suffix = str(uid)
     handle = prefix+"/"+suffix
 
-    # setup connection to handle server
-    client = EUDATHandleClient.instantiate_with_credentials(
-        credentials,
-        **extra_config)
+    try:
+        # setup connection to handle server
+        client = EUDATHandleClient.instantiate_with_credentials(
+            credentials,
+            **extra_config)
+    except HandleNotFoundException:
+        sys.stdout.write('error')
+        return
 
     # pre-process the input parameters for the handle api
     extype = {}
@@ -154,16 +187,27 @@ def create(args):
 def modify(args):
     """perform modify action"""
 
-    # load credentials
-    credentials = PIDClientCredentials.load_from_JSON(args.credpath)
+    try:
+        # load credentials
+        credentials = PIDClientCredentials.load_from_JSON(args.credpath)
+    except CredentialsFormatError:
+        sys.stdout.write('error')
+        return
+    except HandleSyntaxError:
+        sys.stdout.write('error')
+        return
 
     # retrieve and set extra values
     extra_config = {}
 
-    # setup connection to handle server
-    client = EUDATHandleClient.instantiate_with_credentials(
-        credentials,
-        **extra_config)
+    try:
+        # setup connection to handle server
+        client = EUDATHandleClient.instantiate_with_credentials(
+            credentials,
+            **extra_config)
+    except HandleNotFoundException:
+        sys.stdout.write('error')
+        return
 
     kvpairs = dict([(args.key, args.value)])
 
@@ -189,16 +233,27 @@ def modify(args):
 def delete(args):
     """perform delete action"""
 
-    # load credentials
-    credentials = PIDClientCredentials.load_from_JSON(args.credpath)
+    try:
+        # load credentials
+        credentials = PIDClientCredentials.load_from_JSON(args.credpath)
+    except CredentialsFormatError:
+        sys.stdout.write('error')
+        return
+    except HandleSyntaxError:
+        sys.stdout.write('error')
+        return
 
     # retrieve and set extra values
     extra_config = {}
 
-    # setup connection to handle server
-    client = EUDATHandleClient.instantiate_with_credentials(
-        credentials,
-        **extra_config)
+    try:
+        # setup connection to handle server
+        client = EUDATHandleClient.instantiate_with_credentials(
+            credentials,
+            **extra_config)
+    except HandleNotFoundException:
+        sys.stdout.write('error')
+        return
 
     result = 'True'
 
@@ -229,16 +284,27 @@ def delete(args):
 def relation(args):
     """perform the relation action"""
 
-    # load credentials
-    credentials = PIDClientCredentials.load_from_JSON(args.credpath)
+    try:
+        # load credentials
+        credentials = PIDClientCredentials.load_from_JSON(args.credpath)
+    except CredentialsFormatError:
+        sys.stdout.write('error')
+        return
+    except HandleSyntaxError:
+        sys.stdout.write('error')
+        return
 
     # retrieve and set extra values
     extra_config = {}
 
-    # setup connection to handle server
-    client = EUDATHandleClient.instantiate_with_credentials(
-        credentials,
-        **extra_config)
+    try:
+        # setup connection to handle server
+        client = EUDATHandleClient.instantiate_with_credentials(
+            credentials,
+            **extra_config)
+    except HandleNotFoundException:
+        sys.stdout.write('error')
+        return
 
     result = 'None'
 

--- a/cmd/epicclient2.py
+++ b/cmd/epicclient2.py
@@ -103,7 +103,7 @@ def read(args):
             json_result = 'error'
 
         if result is not None:
-           json_result = json.dumps(result["values"])
+            json_result = json.dumps(result["values"])
     else:
         try:
             # retrieve single value from a handle
@@ -259,7 +259,7 @@ def delete(args):
 
     if args.key is None:
         # delete whole handle
-	try:
+        try:
             client.delete_handle(args.handle)
         except HandleAuthenticationError:
             result = 'error'

--- a/scripts/tests/resources/log.manager.conf
+++ b/scripts/tests/resources/log.manager.conf
@@ -1,0 +1,4 @@
+{
+"log_level": "DEBUG",
+"log_dir": "/tmp"
+}

--- a/scripts/tests/testB2SafeCmd.py
+++ b/scripts/tests/testB2SafeCmd.py
@@ -91,6 +91,10 @@ if __name__ == '__main__':
         all_suite.addTest(create_epic_test_suite())
         all_suite.addTest(LogManagerTestCase("test_case"))
         all_suite.addTest(AuthzManagerTestCase("test_case"))
+        all_suite.addTest(unittest.TestLoader().loadTestsFromTestCase(
+            IrodsIntegrationTests))
+        all_suite.addTest(unittest.TestLoader().loadTestsFromTestCase(
+            IrodsB2safeIntegrationTests))
         unittest.TextTestRunner(descriptions=2, verbosity=2).run(all_suite)
 
     else:

--- a/scripts/tests/testB2SafeCmd/epic2intgtest.py
+++ b/scripts/tests/testB2SafeCmd/epic2intgtest.py
@@ -98,6 +98,58 @@ class EpicClient2IntegrationTests(unittest.TestCase):
                         delete_result = subprocess.call([EPIC_PATH, CRED_STORE, CRED_PATH, 'delete', handle])
 
 
+    def test_search_handle_by_key_value(self):
+        """Test that search by key-value returns matching handle."""
+        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'create', 'http://www.testB2SafeCmd.com/1']
+        create_result = subprocess_popen(command)
+        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'search', 'URL', 'http://www.testB2SafeCmd.com/1']
+        search_result = subprocess_popen(command)
+        search_result_json = json.loads(search_result[0])
+        self.assertEqual(
+            create_result[0], search_result_json[0],
+            'search existing handle by key returns unexpected response')
+
+ 
+    def test_search_handle_by_non_existing_key_value(self):
+        """Test that search handle by non existing key-value returns 'empty'."""
+        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'search', 'CHECKSUM', '123456789012345678901234567890']
+        search_result = subprocess_popen(command)
+        self.assertEqual(
+            search_result[0], 'empty',
+            'search handle by non existing key-value should return \"empty\"')
+        
+        
+    def test_retrieve_non_existing_handle(self):
+        """Test that retrieve non existing handle returns None."""
+        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'read', self.prefix+'/1234567890a']
+        read_result = subprocess_popen(command)
+        self.assertEqual(
+          read_result[0], 'None',
+          "retrieve non existing handle should return None")
+
+
+    def test_get_value_from_handle(self):
+        """Test that get value by key returns stored handle value."""
+        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'create', 'http://www.testB2SafeCmd.com/1']
+        create_result = subprocess_popen(command)
+        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'read', create_result[0], '--key', 'URL']
+        read_result = subprocess_popen(command)
+        self.assertEqual(
+            read_result[0], 'http://www.testB2SafeCmd.com/1',
+            'get existing value from handle returns unexpected response')
+    
+    
+    def test_get_non_existing_value_from_handle(self):
+        """Test that get value by non existing key returns None."""
+        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'create', 'http://www.testB2SafeCmd.com/1']
+        create_result = subprocess_popen(command)
+        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'read', create_result[0], '--key', 'FOO_KEY']
+        read_result = subprocess_popen(command)
+        self.assertEqual(
+            read_result[0], 'None',
+            'get value by non existing key should return None')
+ 
+ 
     def test_create_handle(self):
         """Test that create handle returns expected response and adds
         new handle.
@@ -109,7 +161,6 @@ class EpicClient2IntegrationTests(unittest.TestCase):
         search_result_json = json.loads(search_result[0])
         self.assertEqual(create_result[0], search_result_json[0],
                          'create handle should add new handle')
-        
         
         
     def test_create_handle_with_checksum(self):
@@ -151,63 +202,8 @@ class EpicClient2IntegrationTests(unittest.TestCase):
         read_result = subprocess_popen(command)
         self.assertIn(extra_location, read_result[0],
                          'create handle with extra location should add new handle')
-     
-    def test_search_handle_by_key_value(self):
-        """Test that search by key-value returns matching handle."""
-        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'create', 'http://www.testB2SafeCmd.com/1']
-        create_result = subprocess_popen(command)
-        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'search', 'URL', 'http://www.testB2SafeCmd.com/1']
-        search_result = subprocess_popen(command)
-        search_result_json = json.loads(search_result[0])
-        self.assertEqual(
-            create_result[0], search_result_json[0],
-            'search existing handle by key returns unexpected response')
-        
-        
-    def test_search_handle_by_non_existing_key_value(self):
-        """Test that search handle by non existing key-value returns
-        'empty'.
-        """
-        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'search', 'CHECKSUM', '123456789012345678901234567890']
-        search_result = subprocess_popen(command)
-        self.assertEqual(
-            search_result[0], 'empty',
-            'search handle by non existing key-value should return \"empty\"')
-        
-        
-    def test_retrieve_non_existing_handle(self):
-        """Test that retrieve non existing handle returns None."""
-        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'read', self.prefix+'/1234567890a']
-        read_result = subprocess_popen(command)
-        self.assertEqual(
-          read_result[0], 'None',
-          "retrieve non existing handle should return None")
-        
-    
-    def test_get_value_from_handle(self):
-        """Test that get value by key returns stored handle value."""
-        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'create', 'http://www.testB2SafeCmd.com/1']
-        create_result = subprocess_popen(command)
-        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'read', create_result[0], '--key', 'URL']
-        read_result = subprocess_popen(command)
-        self.assertEqual(
-            read_result[0], 'http://www.testB2SafeCmd.com/1',
-            'get existing value from handle returns unexpected response')
-    
-    
-    def test_get_non_existing_value_from_handle(self):
-        """Test that get value by non existing key returns None."""
-        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'create', 'http://www.testB2SafeCmd.com/1']
-        create_result = subprocess_popen(command)
-        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'read', create_result[0], '--key', 'FOO_KEY']
-        read_result = subprocess_popen(command)
-        self.assertEqual(
-            read_result[0], 'None',
-            'get value by non existing key should return None')
-        
-    
-  
-   
+
+
     def test_modify_handle_key_value(self):
         """Test that modify handle value returns True and updates 
         stored value.
@@ -265,52 +261,52 @@ class EpicClient2IntegrationTests(unittest.TestCase):
         
         
     def test_modify_non_existing_handle(self):
-        """Test that modify value of non existing handle returns Nothing."""
+        """Test that modify value of non existing handle returns False."""
         key = "FOO_KEY"
         value = "FOO_VALUE"
         command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'modify', self.prefix+"/1234567890a", key, value]
         modify_result = subprocess_popen(command)
-        self.assertEqual(modify_result[0], '',
-                         'modify non existing handle should return Nothing')
+        self.assertEqual(modify_result[0], 'False',
+                         'modify non existing handle should return False')
         
         
     def test_delete_handle(self):
-        """Test that delete existing handle returns None."""
+        """Test that delete existing handle returns True."""
         command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'create', 'http://www.testB2SafeCmd.com/1']
         create_result = subprocess_popen(command)
         command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'delete', create_result[0]]
         delete_result = subprocess_popen(command)
-        self.assertEqual(delete_result[0], 'None',
-                        'delete existing handle should return None')
+        self.assertEqual(delete_result[0], 'True',
+                        'delete existing handle should return True')
         
     
     def test_delete_non_existing_handle(self):
-        """Test that delete non existing handle returns None."""
-        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'delete', self.prefix+"/1234567890a"]
+        """Test that delete non existing handle returns False."""
+        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'delete', self.prefix+"/1234567890ahabbiebabbie"]
         delete_result = subprocess_popen(command)
-        self.assertEqual(delete_result[0], 'None',
-                        'delete non existing handle should return None')
+        self.assertEqual(delete_result[0], 'False',
+                        'delete non existing handle should return False')
    
     
     def test_delete_key_from_handle(self):
-        """Test that delete key from handle returns None."""
+        """Test that delete key from handle returns True."""
         key = 'EMAIL'
         value = 'user@testB2SafeCmd.com'
         command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'create', 'http://www.testB2SafeCmd.com/1', '--extratype', key+"="+value]
         create_result = subprocess_popen(command)
         command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'delete', create_result[0], '--key', key ]
         delete_result = subprocess_popen(command)
-        self.assertEqual(delete_result[0], 'None',
-                        'delete existing handle value should return None')
+        self.assertEqual(delete_result[0], 'True',
+                        'delete existing handle value should return True')
         
         
     def test_delete_non_existing_key_from_handle(self):
-        """Test that delete non existing key from handle returns Nothing."""
+        """Test that delete non existing key from handle returns False."""
         key = 'FOO_KEY'
         command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'delete', self.prefix+"/1234567890a", '--key', key]
         delete_result = subprocess_popen(command)
-        self.assertEqual(delete_result[0], '',
-                         'delete key from non existing handle should return Nothing')
+        self.assertEqual(delete_result[0], 'False',
+                         'delete key from non existing handle should return False')
 
    
     def test_update_handle_with_location(self):
@@ -332,25 +328,21 @@ class EpicClient2IntegrationTests(unittest.TestCase):
 
 
     def test_modify_existing_handle_with_same_location(self):
-        """Test that update handle with same location value returns 
-        None.
-        """
+        """Test that update handle with same location value returns None."""
         extra_location = '846/157c344a-0179-11e2-9511-00215ec779a8'
         command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'create', 'http://www.testB2SafeCmd.com/1', '--loc10320', extra_location ]
         create_result = subprocess_popen(command)
         command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'relation', create_result[0], extra_location]
         relation_result = subprocess_popen(command)
         self.assertEqual(relation_result[0], 'None',
-                         'modify existing handle with same location value should return None')
+                         'modify existing handle with same location value should return False')
         
         
     def test_update_non_existing_handle_with_location(self):
-        """Test that update non existing handle with location returns
-        Nothing.
-        """
+        """Test that update non existing handle with location returns False."""
         extra_location = '846/157c344a-0179-11e2-9511-00215ec779a8'
         command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'relation', self.prefix+"/1234567890a", extra_location]
         relation_result = subprocess_popen(command)
-        self.assertEqual(relation_result[0], '',
-                         'modify non existing handle with location should return Nothing')
+        self.assertEqual(relation_result[0], 'False',
+                         'modify non existing handle with location should return False')
 

--- a/scripts/tests/testB2SafeCmd/epic2intgtest.py
+++ b/scripts/tests/testB2SafeCmd/epic2intgtest.py
@@ -203,7 +203,45 @@ class EpicClient2IntegrationTests(unittest.TestCase):
         self.assertIn(extra_location, read_result[0],
                          'create handle with extra location should add new handle')
 
+    def test_create_handle_with_extra_key_ROR_real_pid(self):
+        """Test that create handle with extra key EUDAT/ROR returns expected 
+        response and adds new handle with supplied key value.
+        """
+        extra_key = 'EUDAT/ROR'
+        extra_value = '841/totally_nonsen_suffix'
+        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'create', '--extratype', extra_key+'='+extra_value, 'http://www.testB2SafeCmd.com/1']
+        create_result = subprocess_popen(command)
+        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'read', create_result[0], '--key', extra_key]
+        read_result = subprocess_popen(command)
+        self.assertEqual(extra_value, read_result[0],
+                         'create handle with extra key EUDAT/ROR should add new handle')
 
+    def test_create_handle_with_extra_key_ROR_pid(self):
+        """Test that create handle with extra key EUDAT/ROR and value 'pid' returns expected 
+        response and adds new handle with supplied key value.
+        """
+        extra_key = 'EUDAT/ROR'
+        extra_value = 'pid'
+        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'create', '--extratype', extra_key+'='+extra_value, 'http://www.testB2SafeCmd.com/1']
+        create_result = subprocess_popen(command)
+        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'read', create_result[0], '--key', extra_key]
+        read_result = subprocess_popen(command)
+        self.assertEqual(create_result[0], read_result[0],
+                         'create handle with extra key EUDAT/ROR an value pid should add new handle')
+
+    def test_create_handle_with_extra_key_ROR_PID(self):
+        """Test that create handle with extra key EUDAT/ROR and value 'PID' returns expected 
+        response and adds new handle with supplied key value.
+        """
+        extra_key = 'EUDAT/ROR'
+        extra_value = 'PID'
+        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'create', '--extratype', extra_key+'='+extra_value, 'http://www.testB2SafeCmd.com/1']
+        create_result = subprocess_popen(command)
+        command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'read', create_result[0], '--key', extra_key]
+        read_result = subprocess_popen(command)
+        self.assertEqual(create_result[0], read_result[0],
+                         'create handle with extra key EUDAT/ROR an value pid should add new handle')
+  
     def test_modify_handle_key_value(self):
         """Test that modify handle value returns True and updates 
         stored value.

--- a/scripts/tests/testB2SafeCmd/epicintgtest.py
+++ b/scripts/tests/testB2SafeCmd/epicintgtest.py
@@ -156,8 +156,58 @@ class EpicClientIntegrationTests(unittest.TestCase):
             self.cred.prefix, location_key, 'TEST_CR1')
         self.assertIn(extra_location, retrieve_result,
                          'create handle with extra location should add new handle')
-   
-   
+
+    def test_create_handle_with_extra_key_ROR_real_pid(self):
+        """Test that create handle with extra key EUDAT/ROR returns expected 
+        response and adds new handle with supplied key value.
+        """
+        extra_key = 'EUDAT/ROR'
+        extra_value = '841/totally_nonsen_suffix'
+        create_result = self.client.createHandle(
+            self.cred.prefix, 'http://www.testB2SafeCmd.com/1', None, 
+            [str(extra_key+'='+extra_value)], None, 'TEST_CR1')
+        self.assertEqual(
+            create_result, str(self.cred.prefix + "/TEST_CR1"),
+            "create handle with extra key returns unexpected response")
+        retrieve_result = self.client.getValueFromHandle(
+            self.cred.prefix, extra_key, 'TEST_CR1')
+        self.assertEqual(extra_value, retrieve_result,
+                         'create handle with extra key EUDAT/ROR should add new handle')
+
+    def test_create_handle_with_extra_key_ROR_pid(self):
+        """Test that create handle with extra key EUDAT/ROR and value 'pid' returns expected 
+        response and adds new handle with supplied key value.
+        """
+        extra_key = 'EUDAT/ROR'
+        extra_value = 'pid'
+        create_result = self.client.createHandle(
+            self.cred.prefix, 'http://www.testB2SafeCmd.com/1', None, 
+            [str(extra_key+'='+extra_value)], None, 'TEST_CR1')
+        self.assertEqual(
+            create_result, str(self.cred.prefix + "/TEST_CR1"),
+            "create handle with extra location returns unexpected response")
+        retrieve_result = self.client.getValueFromHandle(
+            self.cred.prefix, extra_key, 'TEST_CR1')
+        self.assertEqual(create_result, retrieve_result,
+                         'create handle with extra key EUDAT/ROR and value pid should add new handle')
+
+    def test_create_handle_with_extra_key_ROR_PID(self):
+        """Test that create handle with extra key EUDAT/ROR and value 'PID' returns expected 
+        response and adds new handle with supplied key value.
+        """
+        extra_key = 'EUDAT/ROR'
+        extra_value = 'PID'
+        create_result = self.client.createHandle(
+            self.cred.prefix, 'http://www.testB2SafeCmd.com/1', None, 
+            [str(extra_key+'='+extra_value)], None, 'TEST_CR1')
+        self.assertEqual(
+            create_result, str(self.cred.prefix + "/TEST_CR1"),
+            "create handle with extra location returns unexpected response")
+        retrieve_result = self.client.getValueFromHandle(
+            self.cred.prefix, extra_key, 'TEST_CR1')
+        self.assertEqual(create_result, retrieve_result,
+                         'create handle with extra key EUDAT/ROR and value pid should add new handle')
+
     def test_create_existing_handle(self):
         """Test that create existing handle returns None."""
         self.client.createHandle(self.cred.prefix, 

--- a/scripts/tests/testB2SafeCmd/irodsb2safetest.py
+++ b/scripts/tests/testB2SafeCmd/irodsb2safetest.py
@@ -87,7 +87,7 @@ def put_irods_file(input_file, output_file):
     return put_result
 
 def replicate_irods_file(source, destination, registered, recursive):
-    '''procedure to replicate a file with EUDAT rulesin iRODS'''
+    '''procedure to replicate a file with EUDAT rules in iRODS'''
     # create test rule to replicate file
     irule_rule = "{*status = EUDATReplication(*source, *destination, *registered, *recursive, *response); if (*status) { writeLine('stdout', 'Success!'); } else { writeLine('stdout', 'Failed: *response'); }}"
     irule_input = '*source='+source+'%*destination='+destination+'%*registered='+registered+'+%*recursive='+recursive

--- a/scripts/tests/testB2SafeCmd/testLogManager.py
+++ b/scripts/tests/testB2SafeCmd/testLogManager.py
@@ -19,6 +19,6 @@ class LogManagerTestCase(unittest.TestCase):
     def test_case(self):
         
         args = argparse.Namespace()
-        args.conffilepath = '../../conf/log.manager.conf'
+        args.conffilepath = 'resources/log.manager.conf'
         args.debug = False
         logmanager.test(args)


### PR DESCRIPTION
include exception handlers for actions done in epicclient2.py. This helps causing epicclient2.py output to be more in line with epicclient.py.

update epic2inttest.py to behave more like epicintgtest.py. Expect same return values and same order of tests as epicintgtest.py.

1 test fails because it seems that the b2handle library has a very minor bug. When deleting an non-existent handle it gives back `True` instead of `False` because no exception is raised in the b2handle library. And the raised exception would have caused the set return value to be `False` in this case.
