### PR TITLE
Pidprofile set EUDAT/CHECKSUM_TIMESTAMP to ISO 8601 time format

### DIFF
--- a/cmd/timeconvert.py
+++ b/cmd/timeconvert.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import calendar
+import datetime as DT
+import sys
+
+def epoch_to_iso8601(timestamp):
+    """
+    epoch_to_iso8601 - convert the unix epoch time into a iso8601 formatted date
+    >>> epoch_to_iso8601(1449147762)
+    '2015-12-03T13:02:42Z'
+    """
+    iso_time = DT.datetime.utcfromtimestamp(timestamp).isoformat()+"Z"
+    print iso_time
+
+def iso8601_to_epoch(dateTime_string):
+    """
+    iso8601_to_epoch - convert a iso8601 formatted date into the unix epoch time 
+    >>> iso8601_to_epoch('2015-12-03T13:02:42Z')
+    1449147762
+    """
+    epoch_time =  calendar.timegm(DT.datetime.strptime(dateTime_string, "%Y-%m-%dT%H:%M:%SZ").timetuple())
+    print epoch_time
+
+if __name__ == "__main__":
+
+     if sys.argv[1] == 'epoch_to_iso8601':
+         epoch_to_iso8601(float(sys.argv[2])) 
+     elif sys.argv[1] == 'iso8601_to_epoch':
+         iso8601_to_epoch(sys.argv[2])
+     else:
+         print "Error, not valid option"
+

--- a/rulebase/pid-service.re
+++ b/rulebase/pid-service.re
@@ -54,13 +54,7 @@ EUDATCreatePID(*parent_pid, *path, *ror, *fio, *fixed, *newPID) {
 
     logInfo("[EUDATCreatePID] create pid for *path");
     *version = "1";
-    # extra debug info
-    logInfo("ror=*ror");
-    logInfo("fio=*fio");
-    logInfo("fixed=*fixed");
-    # end extra debug info
-    logDebug("[EUDATCreatePID] input parameters: parent=*parent_pid, path=*path, ror=*ror,"
-             ++ "fio=*fio, fixed=*fixed");
+    logDebug("[EUDATCreatePID] input parameters: parent=*parent_pid, path=*path, ror=*ror, fio=*fio, fixed=*fixed");
     if (!EUDATisMetadata(*path)) {
         getEpicApiParameters(*credStoreType, *credStorePath, *epicApi, *serverID, *epicDebug);
         getConfParameters(*msiFreeEnabled, *msiCurlEnabled, *authzEnabled);
@@ -404,7 +398,7 @@ EUDATePIDcreate(*path, *extraType, *PID) {
         } else {
             *extraType = "EUDAT/CHECKSUM=*checksum";
         }
-        *execCmd = "epoch_to_iso8601  *modtime";
+        *execCmd=" epoch_to_iso8601  *modtime";
         msiExecCmd("timeconvert.py","*execCmd","null", "null", "null", *outGRP9);
         msiGetStdoutInExecCmdOut(*outGRP9, *modtime_iso8601);
         getConfParameters(*msiFreeEnabled, *msiCurlEnabled, *authzEnabled);

--- a/rulebase/pid-service.re
+++ b/rulebase/pid-service.re
@@ -404,7 +404,14 @@ EUDATePIDcreate(*path, *extraType, *PID) {
         } else {
             *extraType = "EUDAT/CHECKSUM=*checksum";
         }
-        *extraType = "*extraType"++";EUDAT/CHECKSUM_TIMESTAMP=*modtime";
+        *execCmd = "epoch_to_iso8601  *modtime";
+        msiExecCmd("timeconvert.py","*execCmd","null", "null", "null", *outGRP9);
+        msiGetStdoutInExecCmdOut(*outGRP9, *modtime_iso8601);
+        getConfParameters(*msiFreeEnabled, *msiCurlEnabled, *authzEnabled);
+        if (*msiFreeEnabled) {
+            msifree_microservice_out(*outGRP9);
+        }
+         *extraType = "*extraType"++";EUDAT/CHECKSUM_TIMESTAMP=*modtime_iso8601";
     }
 
     logInfo("[EUDATePIDcreate] Create PID (CHECKSUM:*checksum, OBJPATH:*path) as user: $userNameClient");

--- a/rulebase/replication.re
+++ b/rulebase/replication.re
@@ -358,7 +358,15 @@ EUDATPIDRegistration(*source, *destination, *notification, *registration_respons
     }
     else {
         *parentROR = EUDATSearchAndDefineField(*source, *parentPID, "EUDAT/ROR");
+        if (*parentROR == "None") {
+            logDebug("EUDAT/ROR was empty, using parent PID");
+            *parentROR = *parentPID;
+        }
         *fio = EUDATSearchAndDefineField(*source, *parentPID, "EUDAT/FIO");
+        if (*fio == "None") {
+            logDebug("EUDAT/FIO was empty, using parent PID");
+            *fio = *parentPID;
+        }
         *fixed = EUDATSearchAndDefineField(*source, *parentPID, "EUDAT/FIXED_CONTENT");
         logDebug("[EUDATPIDRegistration] the path *destination has EUDAT/PARENT=*parentPID, "
                  ++ "EUDAT/ROR=*parentROR, EUDAT/FIO=*fio, EUDAT/FIXED_CONTENT=*fixed");


### PR DESCRIPTION
Create python function to convert epoch time to ISO 8601 time format in zulu time.
Call python function to set `EUDAT/CHECKSUM_TIMESTAMP` just before uploading it to a PID/handle record

remove some obsolete debug statements
