### PR TITLE
Some modifications of the test_suite.sh

### DIFF
--- a/scripts/tests/test_suite.sh
+++ b/scripts/tests/test_suite.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-REMOTE_ZONE=cinecaDMPZone1
-DEFAULT_RESC=defaultRescFoo
+# Get command line args:
+DEFAULT_RESC=$1
+REMOTE_ZONE=$2
+if [ -z $REMOTE_ZONE ] || [ -z $DEFAULT_RESC ]
+then
+    echo "Please provide args (1) default resource and (2) remote zone to be used for replication."
+    exit 1
+fi
 
 echo "Hello World!" > test_data.txt
 iput test_data.txt
@@ -24,7 +30,7 @@ fi
 irods_default_resource=`ienv | grep irods_default_resource | cut -d '-' -f 2 | tr -d '[[:space:]]'`
 if [ -z $irods_default_resource ]
 then
-    echo "No irods_default_resource found in ienv output."
+    echo "No irods_default_resource found in ienv output. Using the one from command line."
     irods_default_resource=$DEFAULT_RESC
 fi
 

--- a/scripts/tests/test_suite.sh
+++ b/scripts/tests/test_suite.sh
@@ -9,13 +9,6 @@ then
     exit 1
 fi
 
-echo "Hello World!" > test_data.txt
-iput test_data.txt
-rm test_data.txt
-echo "############ Data Object ############"
-ils -l test_data.txt
-echo ""
-
 # Get user name and zone name from ienv
 irods_user_name=`ienv | grep irods_user_name | cut -d '-' -f 2 | tr -d '[[:space:]]'`
 irods_zone_name=`ienv | grep irods_zone_name | cut -d '-' -f 2 | tr -d '[[:space:]]'`
@@ -36,6 +29,30 @@ fi
 
 # Define test file
 sourcePath="${irods_home}/test_data.txt"
+# If exists, ask whether replace or exit
+exists=`ils ${irods_home} | grep test_data.txt`
+if [ ! -z $exists ]
+then
+    echo "The file $sourcePath already exists. Remove it before continuing (y or n)? Otherwise, script will exit."
+    read shouldRemove
+    echo "You entered $shouldRemove"
+    if [ $shouldRemove == "y" ]
+    then
+        echo "Will be removed"
+        irm $sourcePath
+    else
+        echo "Exiting..."
+        exit 1
+    fi
+fi
+
+echo "Hello World!" > test_data.txt
+iput test_data.txt
+rm test_data.txt
+echo "############ Data Object ############"
+ils -l test_data.txt
+echo ""
+
 
 createPID () {
   rule="{EUDATCreatePID(*parent_pid, *path, *ror, *fio, *fixed, *newPID)}"

--- a/scripts/tests/test_suite.sh
+++ b/scripts/tests/test_suite.sh
@@ -9,6 +9,10 @@ then
     exit 1
 fi
 
+# Define test file name
+testFileName="test_data.txt"
+testFileNameRemote="test_data2.txt"
+
 # Get user name and zone name from ienv
 irods_user_name=`ienv | grep irods_user_name | cut -d '-' -f 2 | tr -d '[[:space:]]'`
 irods_zone_name=`ienv | grep irods_zone_name | cut -d '-' -f 2 | tr -d '[[:space:]]'`
@@ -28,9 +32,9 @@ then
 fi
 
 # Define test file
-sourcePath="${irods_home}/test_data.txt"
+sourcePath="${irods_home}/${testFileName}"
 # If exists, ask whether replace or exit
-exists=`ils ${irods_home} | grep test_data.txt`
+exists=`ils ${irods_home} | grep ${testFileName}`
 if [ ! -z $exists ]
 then
     echo "The file $sourcePath already exists. Remove it before continuing (y or n)? Otherwise, script will exit."
@@ -46,11 +50,11 @@ then
     fi
 fi
 
-echo "Hello World!" > test_data.txt
-iput test_data.txt
-rm test_data.txt
+echo "Hello World!" > ${testFileName}
+iput ${testFileName}
+rm ${testFileName}
 echo "############ Data Object ############"
-ils -l test_data.txt
+ils -l ${testFileName}
 echo ""
 
 
@@ -87,7 +91,7 @@ replication () {
   echo ""
   echo "############ REPLICATION ############"
 #  destPath="${irods_home}/test_data2.txt"
-  destPath="/${REMOTE_ZONE}/home/${irods_user_name}#${irods_zone_name}/test_data2.txt"
+  destPath="/${REMOTE_ZONE}/home/${irods_user_name}#${irods_zone_name}/${testFileNameRemote}"
   echo "Replica path: ${destPath}"
   rule="{*status = EUDATReplication(*source, *destination, *registered, *recursive, *response); 
         if (*status) {

--- a/scripts/tests/test_suite.sh
+++ b/scripts/tests/test_suite.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
 
-# Get command line args:
-DEFAULT_RESC=$1
-REMOTE_ZONE=$2
-if [ -z $REMOTE_ZONE ] || [ -z $DEFAULT_RESC ]
+# If no param given: Fail:
+if [ -z $1 ]
 then
-    echo "Please provide args (1) default resource and (2) remote zone to be used for replication."
+    echo "Please provide args (1) remote zone for replication and (2) default resource. The latter is optional. (If not provided, it's taken from the ienv command)."
     exit 1
+fi
+
+# Get remote zone from command line arg:
+REMOTE_ZONE=$1
+
+# If a second arg is given, it's the resource:
+if [ ! -z $2 ]
+then
+    DEFAULT_RESC=$2
+else
+    DEFAULT_RESC=
 fi
 
 # Define test file name
@@ -23,12 +32,18 @@ then
     echo "No irods_home found in ienv output. Constructing irods_home from zone name and user name."
     irods_home="/${irods_zone_name}/home/${irods_user_name}"
 fi
-# Get default resc (not in ienv output)
-irods_default_resource=`ienv | grep irods_default_resource | cut -d '-' -f 2 | tr -d '[[:space:]]'`
+# If not provided via command line, get default resc from in ienv output
+if [ -z $DEFAULT_RESC ]
+then
+    irods_default_resource=`ienv | grep irods_default_resource | cut -d '-' -f 2 | tr -d '[[:space:]]'`
+else
+    irods_default_resource=$DEFAULT_RESC
+fi
+# If it's neither provided nor found in ienv, exit!
 if [ -z $irods_default_resource ]
 then
-    echo "No irods_default_resource found in ienv output. Using the one from command line."
-    irods_default_resource=$DEFAULT_RESC
+    echo "No irods_default_resource found in ienv output nor passed as argument. Exiting. Please provide it as command line argument"
+    exit
 fi
 
 # Define test file

--- a/scripts/tests/test_suite.sh
+++ b/scripts/tests/test_suite.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 REMOTE_ZONE=cinecaDMPZone1
+DEFAULT_RESC=defaultRescFoo
 
 echo "Hello World!" > test_data.txt
 iput test_data.txt
@@ -9,10 +10,25 @@ echo "############ Data Object ############"
 ils -l test_data.txt
 echo ""
 
-irods_home=`ienv | grep irods_home | cut -d '-' -f 2 | tr -d '[[:space:]]'`
+# Get user name and zone name from ienv
 irods_user_name=`ienv | grep irods_user_name | cut -d '-' -f 2 | tr -d '[[:space:]]'`
 irods_zone_name=`ienv | grep irods_zone_name | cut -d '-' -f 2 | tr -d '[[:space:]]'`
+# Get home dir (not in ienv output)
+irods_home=`ienv | grep irods_home | cut -d '-' -f 2 | tr -d '[[:space:]]'`
+if [ -z $irods_home  ]
+then
+    echo "No irods_home found in ienv output. Constructing irods_home from zone name and user name."
+    irods_home="/${irods_zone_name}/home/${irods_user_name}"
+fi
+# Get default resc (not in ienv output)
 irods_default_resource=`ienv | grep irods_default_resource | cut -d '-' -f 2 | tr -d '[[:space:]]'`
+if [ -z $irods_default_resource ]
+then
+    echo "No irods_default_resource found in ienv output."
+    irods_default_resource=$DEFAULT_RESC
+fi
+
+# Define test file
 sourcePath="${irods_home}/test_data.txt"
 
 createPID () {

--- a/scripts/tests/test_suite.sh
+++ b/scripts/tests/test_suite.sh
@@ -108,14 +108,20 @@ replication () {
   output="*FVALUE"
   pid_raw=`irule "${rule}" "${input}" "${output}"`
   pid=`echo ${pid_raw} | cut -d '=' -f 2 | tr -d '[[:space:]]'`
+  if [ -z $pid ]
+  then
+    echo "        ERROR! Did not find PID in irods metadata for ${destPath}! Cannot retrieve values from the PID record. Please check what went wrong."
+  fi
   echo "        PID: ${pid}"
   
+  # The following loop could be places in an else clause, but then the user might not notice the failures, so let it fail...
   for k in "URL" "CHECKSUM" "EUDAT/CHECKSUM" "EUDAT/CHECKSUM_TIMESTAMP" "EUDAT/ROR" "EUDAT/FIO" "EUDAT/FIXED_CONTENT" "EUDAT/PARENT"
   do
       raw=`irule "{*res=EUDATGeteValPid(*pid, *key)}" "*pid=${pid}%*key=$k" "*res"`
       val=`echo ${raw} | cut -d '=' -f 2 | tr -d '[[:space:]]'`
       echo "        $k: ${val}"
   done
+  
   echo "        ############ iCAT key/value pairs: ############"
   for k in "PID" "EUDAT/ROR" "EUDAT/FIO" "EUDAT/PARENT" "EUDAT/FIXED_CONTENT" "eudat_dpm_checksum_date:${irods_default_resource}"
   do


### PR DESCRIPTION
Hi,
during installation and testing of by B2Safe instance, I've made some adaptations to the test_suite. If you consider these useful, feel free to merge them.

Summary:

- In the replication test suite, the remote zone has to be passed as command line argument. It used to be hard-coded.
- The default resource may be passed as a command line argument. Otherwise it is read from environment config ("ienv"). But as it is not always contained in the config, so if it's neither passed nor contained in the config, the script exits.
- The irods_home variable is now constructed from other environment config, if not contained in the environment config.
- Detail: The file names of the test files are implemented as variables, so they can be more easily adapted if needed
- Detail: Added log error message for a rare error (when no PID is found in irods metadata, e.g. after interrupting the test_suite).
- Detail: User is prompted whether to remove test file if it was already there. Only relevant for debugging, where script may interrupt before test file is removed.