### PR TITLE
Remove obsolete parameters: MSICURL_ENABLED & MSIFREE_ENABLED and add new one

### DIFF
--- a/install.txt
+++ b/install.txt
@@ -65,9 +65,6 @@ sudo su - $IRODS_SERVICE_ACCOUNT_NAME -s "/bin/bash" -c "cd /opt/eudat/b2safe/pa
 NOTE: following needs to be updated/added in "/opt/eudat/b2safe/packaging/install.conf":
    - DEFAULT_RESOURCE
    - SERVER_ID
-   - BASE_URI (needed for old epicclient) (OBSOLETE, so make it a comment)
-   - USERNAME (needed for old epicclient) (OBSOLETE, so make it a comment)
-   - PREFIX   (needed for old epicclient) (OBSOLETE, so make it a comment)
    - HANDLE_SERVER_URL      (needed for epicclient2)
    - PRIVATE_KEY            (needed for epicclient2)
    - CERTIFICATE_ONLY       (needed for epicclient2)
@@ -76,8 +73,7 @@ NOTE: following needs to be updated/added in "/opt/eudat/b2safe/packaging/instal
    - REVERSELOOKUP_USERNAME (needed for epicclient2)
    - HTTPS_VERIFY           (needed for epicclient2)
    - AUTHZ_ENABLED (default=true)
-   - MSIFREE_ENABLED (default=true for fresh installation, =false for update)
-   - MSICURL_ENABLED (default=false)
+   - MSG_QUEUE_ENABLED (default=false)
 
 
 - check the python scripts for missing python libraries.

--- a/packaging/create_deb_package.sh
+++ b/packaging/create_deb_package.sh
@@ -124,12 +124,7 @@ SERVER_ID="irods://<fully_qualified_hostname>:1247"
 #
 # epic credentials file usage parameters
 #
-# old epicclient parameters
-#BASE_URI="https://<fully_qualified_hostname_epic_server>/<instance>/handles/"
-#USERNAME=<username_for_prefix>
-#PREFIX=<prefix>
-#
-# new epicclient2 parameters
+# epicclient2 parameters
 HANDLE_SERVER_URL=<https://epic3.storage.surfsara.nl:8001>
 PRIVATE_KEY=</path/prefix_suffix_index_privkey.pem>
 CERTIFICATE_ONLY=</path/prefix_suffix_index_certificate_only.pem>
@@ -152,12 +147,8 @@ LOG_DIR=/var/log/irods
 # check if user is authorized to perform several functions
 AUTHZ_ENABLED=true
 #
-# enable if iRODS contrib package is installed with msifree microservice to
-# prevent memory leaks in iRODS
-MSIFREE_ENABLED=true
-#
-# enable if a speedup is to be used. (won't work in future versions)
-MSICURL_ENABLED=false
+# check if message queue is enabled
+MSG_QUEUE_ENABLED=false
 #
 EOF2
 

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -58,8 +58,7 @@ SHARED_SPACE=
 # sensible defaults are chosen. They can be overridden by adding them to
 # the configuration in install.conf
 AUTHZ_ENABLED=true
-MSIFREE_ENABLED=false
-MSICURL_ENABLED=false
+MSG_QUEUE_ENABLED=false
 #
 #
 #============================================
@@ -691,17 +690,13 @@ update_get_conf_parameters() {
         cp $B2SAFE_LOCALFILE ${B2SAFE_LOCALFILE}.org.${DATE_TODAY} 
     fi
     cat $B2SAFE_LOCALFILE | \
-        awk -F= -v AUTHZ_ENABLED=$AUTHZ_ENABLED -v MSIFREE_ENABLED=$MSIFREE_ENABLED -v MSICURL_ENABLED=$MSICURL_ENABLED '{
+        awk -F= -v AUTHZ_ENABLED=$AUTHZ_ENABLED -v MSG_QUEUE_ENABLED=$MSG_QUEUE_ENABLED '{
             if ( $1 ~ /^ +\*authzEnabled/ ) {
                 $1=$1"=bool(\""AUTHZ_ENABLED"\");"
                 $2=""
-            }
-            if ( $1 ~ /^ +\*msiFreeEnabled/ ) {
-                $1=$1"=bool(\""MSIFREE_ENABLED"\");"
-                $2=""
-            }
-            if ( $1 ~ /^ +\*msiCurlEnabled/ ) {
-                $1=$1"=bool(\""MSICURL_ENABLED"\");"
+            } 
+            if ( $1 ~ /^ +\*messageQueueEnabled/ ) {
+                $1=$1"=\""MSG_QUEUE_ENABLED"\";"
                 $2=""
             } print $0
         }' >  $B2SAFE_LOCALFILE.new

--- a/packaging/irods-eudat-b2safe.spec
+++ b/packaging/irods-eudat-b2safe.spec
@@ -125,14 +125,7 @@ CRED_STORE_TYPE=os
 CRED_FILE_PATH=\$B2SAFE_PACKAGE_DIR/conf/credentials
 SERVER_ID="irods://<fully_qualified_hostname>:1247"
 #
-# epic credentials file usage parameters
-#
-# old epicclient parameters
-#BASE_URI="https://<fully_qualified_hostname_epic_server>/<instance>/handles/"
-#USERNAME=<username_for_prefix>
-#PREFIX=<prefix>
-#
-# new epicclient2 parameters
+# epicclient2 parameters
 HANDLE_SERVER_URL=<https://epic3.storage.surfsara.nl:8001>
 PRIVATE_KEY=</path/prefix_suffix_index_privkey.pem>
 CERTIFICATE_ONLY=</path/prefix_suffix_index_certificate_only.pem>
@@ -155,12 +148,8 @@ LOG_DIR=/var/log/irods
 # check if user is authorized to perform several functions
 AUTHZ_ENABLED=true
 #
-# enable if iRODS contrib package is installed with msifree microservice to
-# prevent memory leaks in iRODS
-MSIFREE_ENABLED=true
-#
-# enable if a speedup is to be used. (won't work in future versions)
-MSICURL_ENABLED=false
+# check if message queue is enabled
+MSG_QUEUE_ENABLED=false
 #
 
 EOF
@@ -193,6 +182,8 @@ fi
 
 
 %changelog
+* Wed Nov 22 2017  Robert Verkerk <robert.verkerk@surfsara.nl> 4.0.1
+- remove obsolete parameters. Only support epicclient2.py
 * Wed Apr 18 2017  Robert Verkerk <robert.verkerk@surfsara.nl> 4.0.0
 - update for better info. Remove requires. iRODS can be in 2 different packages.
 * Fri Nov 20 2015  Robert Verkerk <robert.verkerk@surfsara.nl> 3.0.0

--- a/rulebase/eudat.re
+++ b/rulebase/eudat.re
@@ -235,8 +235,8 @@ EUDATPushObjMetadata(*path, *queue) {
 EUDATMessage(*queue, *message) {
 
     *res = 'None';
-    getMessageParameters(*msgConfPath, *ctrlQName, *enabled);
-    if (*enabled) {
+    getMessageParameters(*msgConfPath, *ctrlQName, *messageQueueEnabled);
+    if (*messageQueueEnabled) {
         logInfo("[EUDATMessage] sending message to the topic '*queue'");
         logVerbose("[EUDATMessage] message '*message'");
         if (*queue == 'None') {

--- a/rulebase/local.re
+++ b/rulebase/local.re
@@ -95,10 +95,10 @@ getLogParameters(*logConfPath) {
 #
 # Author: Claudio Cacciari (Cineca)
 #-------------------------------------------------------------------------------
-getMessageParameters(*msgConfPath, *controlQueueName, *enabled) {
+getMessageParameters(*msgConfPath, *controlQueueName, *messageQueueEnabled) {
     *msgConfPath="/opt/eudat/b2safe/conf/msgManager.conf";
     *controlQueueName="B2SAFE";
-    *enabled=bool("false");
+    *messageQueueEnabled=bool("false");
 }
 
 # Provides parameters for some B2SAFE configurations.


### PR DESCRIPTION
Remove obsolete parameters:
 * MSICURL_ENABLED ==> No curl module anymore
 * MSIFREE_ENABLED ==> No msifree needed when running iRODS 4.2.1. Many memory leaks fixed.
Add new parameter:
 * MSG_QUEUE_ENABLED (default = false). This could enable the message bus.

Update installation scripts.
Remove epicclient.py parameters from standard generated install.conf