### PR TITLE
Bugfix. Prevent adding same handle in replica

### DIFF
--- a/cmd/regex_search_string.py
+++ b/cmd/regex_search_string.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import re
+import sys
+
+def search_pattern_in_string(pattern, string):
+    """
+    search_pattern_in_string. Search if a pattern matches in a string.
+    return match in string if found.
+    return "no match found!" if not found
+    """
+    searchObj = re.search(pattern, string, re.U|re.I)
+    if searchObj:
+        print searchObj.group()
+    else:
+        print "no match found!"
+
+if __name__ == "__main__":
+
+     search_pattern_in_string(sys.argv[1], sys.argv[2])
+

--- a/rulebase/pid-service.re
+++ b/rulebase/pid-service.re
@@ -195,7 +195,9 @@ EUDATUpdatePIDWithNewChild(*parentPID, *childPID) {
         *replicaNew = *childPID;
     }
     else {
-        if (*replica like "*"++*childPID++"*") {
+        msiExecCmd("regex_search_string.py","*childPID *replica", "null", "null", "null", *status);
+        msiGetStdoutInExecCmdOut(*status, *response);
+        if (*response not like "no match found!") {
            *replicaNew = *replica;
         }
         else {

--- a/scripts/tests/testB2SafeCmd/epic2intgtest.py
+++ b/scripts/tests/testB2SafeCmd/epic2intgtest.py
@@ -106,7 +106,7 @@ class EpicClient2IntegrationTests(unittest.TestCase):
         search_result = subprocess_popen(command)
         search_result_json = json.loads(search_result[0])
         self.assertEqual(
-            create_result[0], search_result_json[0],
+            unicode(create_result[0]).lower(), search_result_json[0].lower(),
             'search existing handle by key returns unexpected response')
 
  
@@ -168,7 +168,7 @@ class EpicClient2IntegrationTests(unittest.TestCase):
         command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'search', 'URL', 'http://www.testB2SafeCmd.com/1']
         search_result = subprocess_popen(command)
         search_result_json = json.loads(search_result[0])
-        self.assertEqual(create_result[0], search_result_json[0],
+        self.assertEqual(unicode(create_result[0]).lower(), search_result_json[0].lower(),
                          'create handle should add new handle')
         
         


### PR DESCRIPTION
see issue: #120

Search "eudat/REPLICA" in a case insensitive way using a python helper script.



