### PR TITLE
Implement setting of http api params during configuration of B2SAFE

### DIFF
--- a/packaging/irods-eudat-b2safe.spec
+++ b/packaging/irods-eudat-b2safe.spec
@@ -182,9 +182,11 @@ fi
 
 
 %changelog
+* Thu Nov 22 2018  Robert Verkerk <robert.verkerk@surfsara.nl> 4.2.0
+- add new parameters.
 * Wed Nov 22 2017  Robert Verkerk <robert.verkerk@surfsara.nl> 4.0.1
 - remove obsolete parameters. Only support epicclient2.py
-* Wed Apr 18 2017  Robert Verkerk <robert.verkerk@surfsara.nl> 4.0.0
+* Tue Apr 18 2017  Robert Verkerk <robert.verkerk@surfsara.nl> 4.0.0
 - update for better info. Remove requires. iRODS can be in 2 different packages.
 * Fri Nov 20 2015  Robert Verkerk <robert.verkerk@surfsara.nl> 3.0.0
 - set owner of files during installation of rpm.
@@ -192,7 +194,7 @@ fi
 - remove docs directory.
 * Thu Oct 15 2015  Robert Verkerk <robert.verkerk@surfsara.nl> 3.0
 - add extra files and create docs directory, specify config files.
-* Mon Jul 07 2015  Robert Verkerk <robert.verkerk@surfsara.nl> 3.0
+* Tue Jul 07 2015  Robert Verkerk <robert.verkerk@surfsara.nl> 3.0
 - assign version of package at build time with input parameters 
 * Fri Feb 13 2015  Robert Verkerk <robert.verkerk@surfsara.nl> 3.0
 - Add files to b2safe package

--- a/scripts/tests/testB2SafeCmd/epic2intgtest.py
+++ b/scripts/tests/testB2SafeCmd/epic2intgtest.py
@@ -106,7 +106,7 @@ class EpicClient2IntegrationTests(unittest.TestCase):
         search_result = subprocess_popen(command)
         search_result_json = json.loads(search_result[0])
         self.assertEqual(
-            create_result[0], search_result_json[0],
+            unicode(create_result[0]).lower(), search_result_json[0].lower(),
             'search existing handle by key returns unexpected response')
 
  
@@ -168,7 +168,7 @@ class EpicClient2IntegrationTests(unittest.TestCase):
         command = [EPIC_PATH, CRED_STORE, CRED_PATH, 'search', 'URL', 'http://www.testB2SafeCmd.com/1']
         search_result = subprocess_popen(command)
         search_result_json = json.loads(search_result[0])
-        self.assertEqual(create_result[0], search_result_json[0],
+        self.assertEqual(unicode(create_result[0]).lower(), search_result_json[0].lower(),
                          'create handle should add new handle')
         
         


### PR DESCRIPTION
installation_test1:
```
$ ./install.sh
read_parameters
check username
check iRODS config files
We have iRODS 4.1 or higher. The config files are in json format
check epicclient2 config in install.conf
epicclient2 parameters set. We will use epicclient2
check http api config in install.conf
Please add the following parameters to the file: "/opt/eudat/b2safe/packaging/install.conf"
Update where necessary and rerun the procedure

SERVERAPIREG="https://<hostnameWithFullDomain>/api/registered"
SERVERAPIPUB="https://<hostnameWithFullDomain>/api/pub"

or if no http api is present

SERVERAPIREG="irods://<hostnameWithFullDomain>:1247"
SERVERAPIPUB="irods://<hostnameWithFullDomain>:1247"
```

installation test2:
```
$ ./install.sh
read_parameters
check username
check iRODS config files
We have iRODS 4.1 or higher. The config files are in json format
check epicclient2 config in install.conf
epicclient2 parameters set. We will use epicclient2
check http api config in install.conf
http api parameters set. We will use the http api parameters
create_links
removed ‘/etc/irods/eudat0.re’
removed ‘/etc/irods/eudat1.re’
removed ‘/etc/irods/eudat2.re’
removed ‘/etc/irods/eudat3.re’
removed ‘/etc/irods/eudat4.re’
ln -sf /opt/eudat/b2safe/rulebase/catchError.re /etc/irods/eudat0.re
ln -sf /opt/eudat/b2safe/rulebase/eudat.re /etc/irods/eudat1.re
ln -sf /opt/eudat/b2safe/rulebase/local.re /etc/irods/eudat2.re
ln -sf /opt/eudat/b2safe/rulebase/pid-service.re /etc/irods/eudat3.re
ln -sf /opt/eudat/b2safe/rulebase/replication.re /etc/irods/eudat4.re
update_server_config
*********************************************************************

Please check the file: /etc/irods/server_config.json by hand
    grep -A5 re_rulebase_set /etc/irods/server_config.json

It should only have the following eudat{n}.re files mentioned:
    eudat0.re  eudat1.re  eudat2.re  eudat3.re  eudat4.re

*********************************************************************
update_irods_core_resource
install_python_scripts
rm /var/lib/irods/iRODS/server/bin/cmd/argo.py
ln -sf /opt/eudat/b2safe/cmd/argo.py /var/lib/irods/iRODS/server/bin/cmd/argo.py
rm /var/lib/irods/iRODS/server/bin/cmd/authZmanager.py
ln -sf /opt/eudat/b2safe/cmd/authZmanager.py /var/lib/irods/iRODS/server/bin/cmd/authZmanager.py
rm /var/lib/irods/iRODS/server/bin/cmd/logmanager.py
ln -sf /opt/eudat/b2safe/cmd/logmanager.py /var/lib/irods/iRODS/server/bin/cmd/logmanager.py
rm /var/lib/irods/iRODS/server/bin/cmd/messageManager.py
ln -sf /opt/eudat/b2safe/cmd/messageManager.py /var/lib/irods/iRODS/server/bin/cmd/messageManager.py
rm /var/lib/irods/iRODS/server/bin/cmd/regex_search_string.py
ln -sf /opt/eudat/b2safe/cmd/regex_search_string.py /var/lib/irods/iRODS/server/bin/cmd/regex_search_string.py
rm /var/lib/irods/iRODS/server/bin/cmd/timeconvert.py
ln -sf /opt/eudat/b2safe/cmd/timeconvert.py /var/lib/irods/iRODS/server/bin/cmd/timeconvert.py
rm /var/lib/irods/iRODS/server/bin/cmd/epicclient.py
ln -sf /opt/eudat/b2safe/cmd/epicclient2.py /var/lib/irods/iRODS/server/bin/cmd/epicclient.py
update_get_epic_api_parameters
update_epicclient2_credentials
enter the password belonging to the credentals of reverse lookup username: 21.T12996 for prefix: 21.T12996 :
update_authz_map_json
update_log_manager_conf
update_metadata_manager
update_conf_parameters
update_http_api_parameters
```